### PR TITLE
Modify the PostMonthlyGroupTransactionsAccount handler

### DIFF
--- a/acount-rest-service/docker/mysql/initdb.d/1_create_tables.sql
+++ b/acount-rest-service/docker/mysql/initdb.d/1_create_tables.sql
@@ -159,5 +159,6 @@ CREATE TABLE group_accounts
   payment_confirmation bit(1) NOT NULL DEFAULT b'0',
   receipt_confirmation bit(1) NOT NULL DEFAULT b'0',
   group_id INT NOT NULL,
-  PRIMARY KEY(id)
+  PRIMARY KEY(id),
+  UNIQUE uq_group_accounts(years_months, payer_user_id, recipient_user_id, group_id)
 );

--- a/acount-rest-service/handler/group_transaction.go
+++ b/acount-rest-service/handler/group_transaction.go
@@ -42,10 +42,6 @@ type GroupTransactionProcessLockErrorMsg struct {
 	Message string `json:"message"`
 }
 
-type GroupAccountConflictErrorMsg struct {
-	Message string `json:"message"`
-}
-
 func NewGroupTransactionsSearchQuery(urlQuery url.Values, groupID string) GroupTransactionsSearchQuery {
 	startDate := trimDate(urlQuery.Get("start_date"))
 	endDate := trimDate(urlQuery.Get("end_date"))
@@ -71,9 +67,6 @@ func (e *GroupTransactionProcessLockErrorMsg) Error() string {
 	return e.Message
 }
 
-func (e *GroupAccountConflictErrorMsg) Error() string {
-	return e.Message
-}
 func generateGroupTransactionsSqlQuery(searchQuery GroupTransactionsSearchQuery) (string, error) {
 	query := `
         SELECT
@@ -669,15 +662,6 @@ func (h *DBHandler) PostMonthlyGroupTransactionsAccount(w http.ResponseWriter, r
 		return
 	}
 	lastDay := time.Date(firstDay.Year(), firstDay.Month()+1, 1, 0, 0, 0, 0, firstDay.Location()).Add(-1 * time.Second)
-
-	conflictCheckGroupAccountsList, err := h.GroupTransactionsRepo.GetGroupAccountsList(firstDay, groupID)
-	if err != nil {
-		errorResponseByJSON(w, NewHTTPError(http.StatusInternalServerError, nil))
-		return
-	} else if len(conflictCheckGroupAccountsList) != 0 {
-		errorResponseByJSON(w, NewHTTPError(http.StatusConflict, &GroupAccountConflictErrorMsg{"当月のグループでの取引は会計済みです。"}))
-		return
-	}
 
 	userPaymentAmountList, err := h.GroupTransactionsRepo.GetUserPaymentAmountList(groupID, firstDay, lastDay)
 	if err != nil {

--- a/acount-rest-service/handler/group_transaction_test.go
+++ b/acount-rest-service/handler/group_transaction_test.go
@@ -129,34 +129,16 @@ func (m MockGroupTransactionsRepository) GetUserPaymentAmountList(groupID int, f
 	}, nil
 }
 
-var count int
-
 func (m MockGroupTransactionsRepository) GetGroupAccountsList(yearMonth time.Time, groupID int) ([]model.GroupAccount, error) {
 	if groupID == 1 {
 		return make([]model.GroupAccount, 0), nil
 	}
 
-	if groupID == 2 {
-		return []model.GroupAccount{
-			{ID: 1, GroupID: 2, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID2", Recipient: "userID1", PaymentAmount: 23600, PaymentConfirmation: false, ReceiptConfirmation: false},
-			{ID: 2, GroupID: 2, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID3", Recipient: "userID1", PaymentAmount: 6800, PaymentConfirmation: false, ReceiptConfirmation: false},
-			{ID: 3, GroupID: 2, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID3", Recipient: "userID4", PaymentAmount: 15400, PaymentConfirmation: false, ReceiptConfirmation: false},
-			{ID: 4, GroupID: 2, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID3", Recipient: "userID5", PaymentAmount: 400, PaymentConfirmation: false, ReceiptConfirmation: false},
-		}, nil
-	}
-
-	if count == 0 {
-		count++
-		return make([]model.GroupAccount, 0), nil
-	}
-
-	count = 0
-
 	return []model.GroupAccount{
-		{ID: 1, GroupID: 3, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID2", Recipient: "userID1", PaymentAmount: 23600, PaymentConfirmation: false, ReceiptConfirmation: false},
-		{ID: 2, GroupID: 3, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID3", Recipient: "userID1", PaymentAmount: 6800, PaymentConfirmation: false, ReceiptConfirmation: false},
-		{ID: 3, GroupID: 3, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID3", Recipient: "userID4", PaymentAmount: 15400, PaymentConfirmation: false, ReceiptConfirmation: false},
-		{ID: 4, GroupID: 3, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID3", Recipient: "userID5", PaymentAmount: 400, PaymentConfirmation: false, ReceiptConfirmation: false},
+		{ID: 1, GroupID: 2, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID2", Recipient: "userID1", PaymentAmount: 23600, PaymentConfirmation: false, ReceiptConfirmation: false},
+		{ID: 2, GroupID: 2, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID3", Recipient: "userID1", PaymentAmount: 6800, PaymentConfirmation: false, ReceiptConfirmation: false},
+		{ID: 3, GroupID: 2, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID3", Recipient: "userID4", PaymentAmount: 15400, PaymentConfirmation: false, ReceiptConfirmation: false},
+		{ID: 4, GroupID: 2, Month: time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC), Payer: "userID3", Recipient: "userID5", PaymentAmount: 400, PaymentConfirmation: false, ReceiptConfirmation: false},
 	}, nil
 }
 
@@ -393,11 +375,11 @@ func TestDBHandler_PostMonthlyGroupTransactionsAccount(t *testing.T) {
 		GroupTransactionsRepo: MockGroupTransactionsRepository{},
 	}
 
-	r := httptest.NewRequest("POST", "/groups/3/transactions/2020-07/account", nil)
+	r := httptest.NewRequest("POST", "/groups/2/transactions/2020-07/account", nil)
 	w := httptest.NewRecorder()
 
 	r = mux.SetURLVars(r, map[string]string{
-		"group_id":   "3",
+		"group_id":   "2",
 		"year_month": "2020-07",
 	})
 

--- a/acount-rest-service/handler/testdata/TestDBHandler_PostMonthlyGroupTransactionsAccount/response.json.golden
+++ b/acount-rest-service/handler/testdata/TestDBHandler_PostMonthlyGroupTransactionsAccount/response.json.golden
@@ -1,5 +1,5 @@
 {
-  "group_id": 3,
+  "group_id": 2,
   "month": "2020-07-01T00:00:00Z",
   "group_total_payment_amount": 148000,
   "group_average_payment_amount": 29600,
@@ -7,7 +7,7 @@
   "group_accounts_list": [
     {
       "id": 1,
-      "group_id": 3,
+      "group_id": 2,
       "month": "2020-07-01T00:00:00Z",
       "payer_user_id": "userID2",
       "recipient_user_id": "userID1",
@@ -17,7 +17,7 @@
     },
     {
       "id": 2,
-      "group_id": 3,
+      "group_id": 2,
       "month": "2020-07-01T00:00:00Z",
       "payer_user_id": "userID3",
       "recipient_user_id": "userID1",
@@ -27,7 +27,7 @@
     },
     {
       "id": 3,
-      "group_id": 3,
+      "group_id": 2,
       "month": "2020-07-01T00:00:00Z",
       "payer_user_id": "userID3",
       "recipient_user_id": "userID4",
@@ -37,7 +37,7 @@
     },
     {
       "id": 4,
-      "group_id": 3,
+      "group_id": 2,
       "month": "2020-07-01T00:00:00Z",
       "payer_user_id": "userID3",
       "recipient_user_id": "userID5",

--- a/acount-rest-service/infrastructure/group_transaction.go
+++ b/acount-rest-service/infrastructure/group_transaction.go
@@ -234,7 +234,9 @@ func (r *GroupTransactionsRepository) GetGroupAccountsList(yearMonth time.Time, 
         WHERE
             group_id = ?
         AND
-            years_months = ?`
+            years_months = ?
+        ORDER BY
+            id`
 
 	rows, err := r.MySQLHandler.conn.Queryx(query, groupID, yearMonth)
 	if err != nil {

--- a/todo-rest-service/domain/repository/repository.go
+++ b/todo-rest-service/domain/repository/repository.go
@@ -43,6 +43,6 @@ type GroupTasksRepository interface {
 	GetGroupTasksList(groupID int) ([]model.GroupTask, error)
 	GetGroupTask(groupTasksID int) (*model.GroupTask, error)
 	PostGroupTask(groupTask model.GroupTask, groupID int) (sql.Result, error)
-	PutGroupTask(groupTask *model.GroupTask, groupTasksID int) error
+	PutGroupTask(groupTask *model.GroupTask, groupTasksID int) (sql.Result, error)
 	DeleteGroupTask(groupTasksID int) error
 }

--- a/todo-rest-service/handler/common_test.go
+++ b/todo-rest-service/handler/common_test.go
@@ -1,17 +1,17 @@
 package handler
 
-import "database/sql"
-
 type MockAuthRepository struct{}
 
-type MockSqlResult struct {
-	sql.Result
-}
+type MockSqlResult struct{}
 
 func (t MockAuthRepository) GetUserID(sessionID string) (string, error) {
 	return "userID1", nil
 }
 
 func (r MockSqlResult) LastInsertId() (int64, error) {
+	return 1, nil
+}
+
+func (r MockSqlResult) RowsAffected() (int64, error) {
 	return 1, nil
 }

--- a/todo-rest-service/handler/group_task.go
+++ b/todo-rest-service/handler/group_task.go
@@ -272,20 +272,24 @@ func (h *DBHandler) PostGroupTasksUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := h.GroupTasksRepo.PostGroupTasksUser(groupTasksUser, groupID); err != nil {
-		errorResponseByJSON(w, NewHTTPError(http.StatusInternalServerError, nil))
-		return
-	}
-
-	dbGroupTasksUser, err := h.GroupTasksRepo.GetGroupTasksUser(groupTasksUser, groupID)
+	result, err := h.GroupTasksRepo.PostGroupTasksUser(groupTasksUser, groupID)
 	if err != nil {
 		errorResponseByJSON(w, NewHTTPError(http.StatusInternalServerError, nil))
 		return
 	}
 
+	lastInsertId, err := result.LastInsertId()
+	if err != nil {
+		errorResponseByJSON(w, NewHTTPError(http.StatusInternalServerError, nil))
+		return
+	}
+
+	groupTasksUser.ID = int(lastInsertId)
+	groupTasksUser.GroupID = groupID
+
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusCreated)
-	if err := json.NewEncoder(w).Encode(dbGroupTasksUser); err != nil {
+	if err := json.NewEncoder(w).Encode(&groupTasksUser); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/todo-rest-service/handler/group_task_test.go
+++ b/todo-rest-service/handler/group_task_test.go
@@ -142,21 +142,6 @@ func (m MockGroupTasksRepository) GetGroupTask(groupTasksID int) (*model.GroupTa
 		}, nil
 	}
 
-	if count == 0 {
-		count++
-		return &model.GroupTask{
-			ID:               2,
-			BaseDate:         model.NullTime{NullTime: sql.NullTime{Time: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), Valid: false}},
-			CycleType:        model.NullString{NullString: sql.NullString{String: "", Valid: false}},
-			Cycle:            model.NullInt{Int: 0, Valid: false},
-			TaskName:         "洗濯",
-			GroupID:          1,
-			GroupTasksUserID: model.NullInt{Int: 0, Valid: false},
-		}, nil
-	}
-
-	count = 0
-
 	return &model.GroupTask{
 		ID:               2,
 		BaseDate:         model.NullTime{NullTime: sql.NullTime{Time: time.Date(2020, 9, 3, 0, 0, 0, 0, time.UTC), Valid: true}},
@@ -172,8 +157,8 @@ func (m MockGroupTasksRepository) PostGroupTask(groupTask model.GroupTask, group
 	return MockSqlResult{}, nil
 }
 
-func (m MockGroupTasksRepository) PutGroupTask(groupTask *model.GroupTask, groupTasksID int) error {
-	return nil
+func (m MockGroupTasksRepository) PutGroupTask(groupTask *model.GroupTask, groupTasksID int) (sql.Result, error) {
+	return MockSqlResult{}, nil
 }
 
 func (m MockGroupTasksRepository) DeleteGroupTask(groupTasksID int) error {

--- a/todo-rest-service/handler/group_task_test.go
+++ b/todo-rest-service/handler/group_task_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/paypay3/kakeibo-app-api/todo-rest-service/testutil"
 )
 
-var count int
-
 type MockGroupTasksRepository struct{}
 
 func (m MockGroupTasksRepository) GetGroupTasksUsersList(groupID int) ([]model.GroupTasksUser, error) {
@@ -60,19 +58,7 @@ func (m MockGroupTasksRepository) GetGroupTasksListAssignedToUser(groupID int) (
 }
 
 func (m MockGroupTasksRepository) GetGroupTasksUser(groupTasksUser model.GroupTasksUser, groupID int) (*model.GroupTasksUser, error) {
-	if count == 0 {
-		count++
-		return nil, sql.ErrNoRows
-	}
-
-	count = 0
-
-	return &model.GroupTasksUser{
-		ID:        4,
-		UserID:    "userID4",
-		GroupID:   1,
-		TasksList: make([]model.GroupTask, 0),
-	}, nil
+	return nil, sql.ErrNoRows
 }
 
 func (m MockGroupTasksRepository) PostGroupTasksUser(groupTasksUser model.GroupTasksUser, groupID int) (sql.Result, error) {

--- a/todo-rest-service/handler/testdata/TestDBHandler_PostGroupTasksUser/response.json.golden
+++ b/todo-rest-service/handler/testdata/TestDBHandler_PostGroupTasksUser/response.json.golden
@@ -1,5 +1,5 @@
 {
-  "id": 4,
+  "id": 1,
   "user_id": "userID4",
   "group_id": 1,
   "tasks_list": []

--- a/todo-rest-service/infrastructure/group_task.go
+++ b/todo-rest-service/infrastructure/group_task.go
@@ -196,7 +196,7 @@ func (r *GroupTasksRepository) PostGroupTask(groupTask model.GroupTask, groupID 
 	return result, err
 }
 
-func (r *GroupTasksRepository) PutGroupTask(groupTask *model.GroupTask, groupTasksID int) error {
+func (r *GroupTasksRepository) PutGroupTask(groupTask *model.GroupTask, groupTasksID int) (sql.Result, error) {
 	query := `
         UPDATE
             group_tasks
@@ -209,9 +209,9 @@ func (r *GroupTasksRepository) PutGroupTask(groupTask *model.GroupTask, groupTas
         WHERE
             id = ?`
 
-	_, err := r.MySQLHandler.conn.Exec(query, groupTask.BaseDate, groupTask.CycleType, groupTask.Cycle, groupTask.TaskName, groupTask.GroupTasksUserID, groupTasksID)
+	result, err := r.MySQLHandler.conn.Exec(query, groupTask.BaseDate, groupTask.CycleType, groupTask.Cycle, groupTask.TaskName, groupTask.GroupTasksUserID, groupTasksID)
 
-	return err
+	return result, err
 }
 
 func (r *GroupTasksRepository) DeleteGroupTask(groupTasksID int) error {


### PR DESCRIPTION
PostMonthlyGroupTransactionsAccount handlerを修正しました。

要件として、該当月の会計データがあったら、フロント側で会計するボタンを表示しないようにしました。
該当月の会計データが重複しないよう、group_accounts tableにUNIQUE制約を設けました。