### PR TITLE
Modify DeleteCustomCategory handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | **GET**<br>&emsp;/categories | <pre>200 OK<br>401 Unauthorized<br>500 Internal Server Error</pre> | カテゴリー一覧取得 |
 | **POST**<br>&emsp;/categories/custom-categories | <pre>201 Created<br>400 Bad Request<br>401 Unauthorized<br>409 Conflict<br>500 Internal Server Error</pre> | カスタムカテゴリー追加 |
 | **PUT**<br>&emsp;/categories/custom-categories/{id} | <pre>200 OK<br>400 Bad Request<br>401 Unauthorized<br>409 Conflict<br>500 Internal Server Error</pre> | カスタムカテゴリー更新 |
-| **DELETE**<br>&emsp;/categories/custom-categories/{id} | <pre>200 OK<br>400 Bad Request<br>401 Unauthorized<br>500 Internal Server Error</pre> | カスタムカテゴリー削除 |
+| **DELETE**<br>&emsp;/categories/custom-categories/{id} | <pre>200 OK<br>400 Bad Request<br>401 Unauthorized<br>404 Not Found<br>500 Internal Server Error</pre> | カスタムカテゴリー削除 |
 | **GET**<br>&emsp;/transactions/{year_month} | <pre>200 OK<br>400 Bad Request<br>401 Unauthorized<br>500 Internal Server Error</pre> | 月別家計簿トランザクション一覧取得 |
 | **GET**<br>&emsp;/transactions/latest | <pre>200 OK<br>401 Unauthorized<br>500 Internal Server Error</pre> | 家計簿トランザクション最新更新10件取得 |
 | **POST**<br>&emsp;/transactions | <pre>201 Created<br>400 Bad Request<br>401 Unauthorized<br>500 Internal Server Error</pre> | 家計簿トランザクション追加 |
@@ -44,7 +44,7 @@
 | **GET**<br>&emsp;/groups/{group_id}/categories | <pre>200 OK<br>400 Bad Request<br>401 Unauthorized<br>500 Internal Server Error</pre> | グループカテゴリー一覧取得 |
 | **POST**<br>&emsp;/groups/{group_id}/categories/custom-categories | <pre>201 Created<br>400 Bad Request<br>401 Unauthorized<br>409 Conflict<br>500 Internal Server Error</pre> | グループカスタムカテゴリー追加 |
 | **PUT**<br>&emsp;/groups/{group_id}/categories/custom-categories/{id} | <pre>200 OK<br>400 Bad Request<br>401 Unauthorized<br>409 Conflict<br>500 Internal Server Error</pre> | グループカスタムカテゴリー更新 |
-| **DELETE**<br>&emsp;/groups/{group_id}/categories/custom-categories/{id} | <pre>200 OK<br>400 Bad Request<br>401 Unauthorized<br>500 Internal Server Error</pre> | グループカスタムカテゴリー削除 |
+| **DELETE**<br>&emsp;/groups/{group_id}/categories/custom-categories/{id} | <pre>200 OK<br>400 Bad Request<br>401 Unauthorized<br>404 Not Found<br>500 Internal Server Error</pre> | グループカスタムカテゴリー削除 |
 | **GET**<br>&emsp;/groups/{group_id}/transactions/{year_month} | <pre>200 OK<br>400 Bad Request<br>401 Unauthorized<br>500 Internal Server Error</pre> | 月別グループ家計簿トランザクション一覧取得 |
 | **GET**<br>&emsp;/groups/{group_id}/transactions/latest | <pre>200 OK<br>400 Bad Request<br>401 Unauthorized<br>500 Internal Server Error</pre> | グループ家計簿トランザクション最新更新10件取得 |
 | **POST**<br>&emsp;/groups/{group_id}/transactions | <pre>201 Created<br>400 Bad Request<br>401 Unauthorized<br>500 Internal Server Error</pre> | グループ家計簿トランザクション追加 |

--- a/account-rest-service/domain/repository/repository.go
+++ b/account-rest-service/domain/repository/repository.go
@@ -57,7 +57,8 @@ type GroupCategoriesRepository interface {
 	PostGroupCustomCategory(groupCustomCategory *model.GroupCustomCategory, groupID int) (sql.Result, error)
 	PutGroupCustomCategory(groupCustomCategory *model.GroupCustomCategory) error
 	FindGroupCustomCategoryID(groupCustomCategoryID int) error
-	DeleteGroupCustomCategory(groupCustomCategoryID int) error
+	GetBigCategoryID(groupCustomCategoryID int) (int, error)
+	DeleteGroupCustomCategory(previousGroupCustomCategoryID int, replaceMediumCategoryID int) error
 }
 
 type GroupTransactionsRepository interface {

--- a/account-rest-service/domain/repository/repository.go
+++ b/account-rest-service/domain/repository/repository.go
@@ -23,7 +23,8 @@ type CategoriesRepository interface {
 	FindCustomCategory(customCategory *model.CustomCategory, userID string) error
 	PostCustomCategory(customCategory *model.CustomCategory, userID string) (sql.Result, error)
 	PutCustomCategory(customCategory *model.CustomCategory) error
-	DeleteCustomCategory(customCategoryID int) error
+	GetBigCategoryID(customCategoryID int) (int, error)
+	DeleteCustomCategory(previousCustomCategoryID int, replaceMediumCategoryID int) error
 }
 
 type TransactionsRepository interface {

--- a/account-rest-service/handler/category_test.go
+++ b/account-rest-service/handler/category_test.go
@@ -166,7 +166,11 @@ func (m MockCategoriesRepository) PutCustomCategory(customCategory *model.Custom
 	return nil
 }
 
-func (m MockCategoriesRepository) DeleteCustomCategory(customCategoryID int) error {
+func (m MockCategoriesRepository) GetBigCategoryID(customCategoryID int) (int, error) {
+	return 2, nil
+}
+
+func (m MockCategoriesRepository) DeleteCustomCategory(previousCustomCategoryID int, replaceMediumCategoryID int) error {
 	return nil
 }
 

--- a/account-rest-service/handler/common.go
+++ b/account-rest-service/handler/common.go
@@ -46,6 +46,10 @@ type AuthenticationErrorMsg struct {
 	Message string `json:"message"`
 }
 
+type NotFoundErrorMsg struct {
+	Message string `json:"message"`
+}
+
 type ConflictErrorMsg struct {
 	Message string `json:"message"`
 }
@@ -86,6 +90,10 @@ func (e *AuthenticationErrorMsg) Error() string {
 	return e.Message
 }
 
+func (e *NotFoundErrorMsg) Error() string {
+	return e.Message
+}
+
 func (e *ConflictErrorMsg) Error() string {
 	return e.Message
 }
@@ -106,6 +114,78 @@ func errorResponseByJSON(w http.ResponseWriter, err error) {
 	if err := json.NewEncoder(w).Encode(httpError); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
+}
+
+func replaceMediumCategoryID(bigCategoryID int) (int, error) {
+	if bigCategoryID == 1 {
+		return 5, nil
+	}
+
+	if bigCategoryID == 2 {
+		return 12, nil
+	}
+
+	if bigCategoryID == 3 {
+		return 18, nil
+	}
+
+	if bigCategoryID == 4 {
+		return 28, nil
+	}
+
+	if bigCategoryID == 5 {
+		return 32, nil
+	}
+
+	if bigCategoryID == 6 {
+		return 38, nil
+	}
+
+	if bigCategoryID == 7 {
+		return 45, nil
+	}
+
+	if bigCategoryID == 8 {
+		return 50, nil
+	}
+
+	if bigCategoryID == 9 {
+		return 58, nil
+	}
+
+	if bigCategoryID == 10 {
+		return 65, nil
+	}
+
+	if bigCategoryID == 11 {
+		return 69, nil
+	}
+
+	if bigCategoryID == 12 {
+		return 73, nil
+	}
+
+	if bigCategoryID == 13 {
+		return 79, nil
+	}
+
+	if bigCategoryID == 14 {
+		return 85, nil
+	}
+
+	if bigCategoryID == 15 {
+		return 90, nil
+	}
+
+	if bigCategoryID == 16 {
+		return 95, nil
+	}
+
+	if bigCategoryID == 17 {
+		return 98, nil
+	}
+
+	return 0, &NotFoundErrorMsg{"大カテゴリーに関連する中カテゴリーが見つかりませんでした。"}
 }
 
 func verifySessionID(h *DBHandler, w http.ResponseWriter, r *http.Request) (string, error) {

--- a/account-rest-service/handler/common.go
+++ b/account-rest-service/handler/common.go
@@ -117,72 +117,113 @@ func errorResponseByJSON(w http.ResponseWriter, err error) {
 }
 
 func replaceMediumCategoryID(bigCategoryID int) (int, error) {
-	if bigCategoryID == 1 {
-		return 5, nil
+	const (
+		_ = iota
+		income
+		foodExpenses
+		dailyNecessities
+		hobby
+		entertainment
+		transportation
+		clothes
+		health
+		data
+		education
+		housing
+		waterSupply
+		car
+		insurance
+		tax
+		cash
+		other
+	)
+
+	const (
+		otherIncome           = 5
+		otherFoodExpenses     = 12
+		otherDailyNecessities = 18
+		otherHobby            = 28
+		otherEntertainment    = 32
+		otherTransportation   = 38
+		otherClothes          = 45
+		otherHealth           = 50
+		otherData             = 58
+		otherEducation        = 65
+		otherHousing          = 69
+		otherWaterSupply      = 73
+		otherCar              = 79
+		otherInsurance        = 85
+		otherTax              = 90
+		otherCash             = 95
+		unclearMoney          = 98
+	)
+
+	if bigCategoryID == income {
+		return otherIncome, nil
 	}
 
-	if bigCategoryID == 2 {
-		return 12, nil
+	if bigCategoryID == foodExpenses {
+		return otherFoodExpenses, nil
 	}
 
-	if bigCategoryID == 3 {
-		return 18, nil
+	if bigCategoryID == dailyNecessities {
+		return otherDailyNecessities, nil
 	}
 
-	if bigCategoryID == 4 {
-		return 28, nil
+	if bigCategoryID == hobby {
+		return otherHobby, nil
 	}
 
-	if bigCategoryID == 5 {
-		return 32, nil
+	if bigCategoryID == entertainment {
+		return otherEntertainment, nil
 	}
 
-	if bigCategoryID == 6 {
-		return 38, nil
+	if bigCategoryID == transportation {
+		return otherTransportation, nil
 	}
 
-	if bigCategoryID == 7 {
-		return 45, nil
+	if bigCategoryID == clothes {
+		return otherClothes, nil
 	}
 
-	if bigCategoryID == 8 {
-		return 50, nil
+	if bigCategoryID == health {
+		return otherHealth, nil
 	}
 
-	if bigCategoryID == 9 {
-		return 58, nil
+	if bigCategoryID == data {
+		return otherData, nil
 	}
 
-	if bigCategoryID == 10 {
-		return 65, nil
+	if bigCategoryID == education {
+		return otherEducation, nil
 	}
 
-	if bigCategoryID == 11 {
-		return 69, nil
+	if bigCategoryID == housing {
+		return otherHousing, nil
 	}
 
-	if bigCategoryID == 12 {
-		return 73, nil
+	if bigCategoryID == waterSupply {
+		return otherWaterSupply, nil
 	}
 
-	if bigCategoryID == 13 {
-		return 79, nil
+	if bigCategoryID == car {
+		return otherCar, nil
 	}
 
-	if bigCategoryID == 14 {
-		return 85, nil
+	if bigCategoryID == insurance {
+		return otherInsurance, nil
 	}
 
-	if bigCategoryID == 15 {
-		return 90, nil
+	if bigCategoryID == tax {
+		return otherTax, nil
 	}
 
-	if bigCategoryID == 16 {
-		return 95, nil
+	if bigCategoryID == cash {
+		return otherCash, nil
 	}
 
-	if bigCategoryID == 17 {
-		return 98, nil
+	if bigCategoryID == other {
+		return unclearMoney, nil
 	}
 
 	return 0, &NotFoundErrorMsg{"大カテゴリーに関連する中カテゴリーが見つかりませんでした。"}

--- a/account-rest-service/handler/group_category_test.go
+++ b/account-rest-service/handler/group_category_test.go
@@ -169,7 +169,11 @@ func (m MockGroupCategoriesRepository) FindGroupCustomCategoryID(groupCustomCate
 	return nil
 }
 
-func (m MockGroupCategoriesRepository) DeleteGroupCustomCategory(groupCustomCategoryID int) error {
+func (m MockGroupCategoriesRepository) GetBigCategoryID(groupCustomCategoryID int) (int, error) {
+	return 2, nil
+}
+
+func (m MockGroupCategoriesRepository) DeleteGroupCustomCategory(previousGroupCustomCategoryID int, replaceMediumCategoryID int) error {
 	return nil
 }
 


### PR DESCRIPTION
DeleteCustomCategory handlerを修正しました。

DB transaction処理:
transactionsテーブルののcustom_category_idをnull, medium_category_idをデフォルト中カテゴリーにセット
↓
custom_categoriesテーブルのカスタムカテゴリーを削除