### PR TITLE
Update go version of Docker image to v1.16.2

### DIFF
--- a/account-rest-service/Dockerfile
+++ b/account-rest-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.2-alpine3.12 as builder
+FROM golang:1.16.2-alpine3.13 as builder
 WORKDIR /go/src/account-rest-service
 COPY go.mod go.sum ./
 RUN go mod download

--- a/todo-rest-service/Dockerfile
+++ b/todo-rest-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.2-alpine3.12 as builder
+FROM golang:1.16.2-alpine3.13 as builder
 WORKDIR /go/src/todo-rest-service
 COPY go.mod go.sum ./
 RUN go mod download

--- a/user-rest-service/Dockerfile
+++ b/user-rest-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.2-alpine3.12 as builder
+FROM golang:1.16.2-alpine3.13 as builder
 WORKDIR /go/src/user-rest-service
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
中間imageのgo versionをv1.16.2へ更新。