### PR TITLE
Update Go version of Docker image to v1.16.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ https://www.shakepiper.com
 
 **<ins>Language</ins>**
 
-- Go v1.16.2
+- Go v1.16.3
 
 ### 【 _Infrastructure_ 】
 

--- a/account-rest-service/Dockerfile
+++ b/account-rest-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.2-alpine3.13 as builder
+FROM golang:1.16.3-alpine3.13 as builder
 WORKDIR /go/src/account-rest-service
 COPY go.mod go.sum ./
 RUN go mod download

--- a/todo-rest-service/Dockerfile
+++ b/todo-rest-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.2-alpine3.13 as builder
+FROM golang:1.16.3-alpine3.13 as builder
 WORKDIR /go/src/todo-rest-service
 COPY go.mod go.sum ./
 RUN go mod download

--- a/user-rest-service/Dockerfile
+++ b/user-rest-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.2-alpine3.13 as builder
+FROM golang:1.16.3-alpine3.13 as builder
 WORKDIR /go/src/user-rest-service
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
Docker imageのGo versionを`v1.16.2` --> `v1.16.3`へ更新。